### PR TITLE
fix: authenticate CI/CD with npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ tmp/
 .env.development.local
 .env.test.local
 .env.production.local
-.npmrc
 .rpt2_cache
 .yarn/*
 !.yarn/releases

--- a/packages/api-derive/.npmrc
+++ b/packages/api-derive/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:always-auth=true
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/api-options/.npmrc
+++ b/packages/api-options/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:always-auth=true
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/types-known/.npmrc
+++ b/packages/types-known/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:always-auth=true
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/types/.npmrc
+++ b/packages/types/.npmrc
@@ -1,0 +1,3 @@
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:always-auth=true
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/polkadot-ci-ghact-build.js
+++ b/polkadot-ci-ghact-build.js
@@ -35,7 +35,7 @@ function npmPublish () {
   }
 
   rimraf.sync('build/package.json');
-  ['LICENSE', 'README.md', 'package.json'].forEach((file) => cpx.copySync(file, 'build'));
+  ['LICENSE', 'README.md', 'package.json', '.npmrc'].forEach((file) => cpx.copySync(file, 'build'));
 
   process.chdir('build');
 


### PR DESCRIPTION
fix npm publish issue

npm notice 
npm ERR! code E404
npm ERR! 404 Not Found - PUT https://registry.npmjs.org/@darwinia%2fapi-derive - Not found
npm ERR! 404 
npm ERR! 404  '@darwinia/api-derive@2.7.5' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-04-19T02_41_57_086Z-debug.log
Error: Process completed with exit code 255.